### PR TITLE
Random seed added as input to samplers under test

### DIFF
--- a/barbarik.py
+++ b/barbarik.py
@@ -171,10 +171,10 @@ class SolutionRetriver:
 
     @staticmethod
     def getSolutionFromUniform(inputFile, numSolutions):
-        return SolutionRetriver.getSolutionFromSPUR(inputFile, numSolutions)
+        return SolutionRetriver.getSolutionFromMUSE(inputFile, numSolutions)
 
     @staticmethod
-    def getSolutionFromSPUR(inputFile, numSolutions):
+    def getSolutionFromMUSE(inputFile, numSolutions):
         inputFileSuffix = inputFile.split('/')[-1][:-4]
         tempOutputFile = tempfile.gettempdir()+'/'+inputFileSuffix+".out"
         cmd = './spur -q -s '+str(numSolutions)+' -out '+str(tempOutputFile)+' -cnf '+str(inputFile)


### PR DESCRIPTION
If we keep the seed same for each sampling call, the samples are not "independent".
Since only AppMC exposed the seed parameter, I've only used the seed for AppMC.